### PR TITLE
Phase A2: refine summary question copy

### DIFF
--- a/src/app/app/case/[id]/intake/_engine/questions.ts
+++ b/src/app/app/case/[id]/intake/_engine/questions.ts
@@ -96,8 +96,8 @@ export function buildQuestions(ctx: Ctx): Question[] {
         {
             id: "summary",
             key: "summary",
-            label: "In one sentence: what happened?",
-            help: "Keep it factual and specific (this anchors your timeline).",
+            label: "Briefly describe what happened",
+            help: "Stick to the facts (what, where, when). Avoid opinions for now.",
             type: "text",
             required: true,
             group: "CORE",


### PR DESCRIPTION
- Refines existing `summary` question wording for clarity
- Updates label to: "Briefly describe what happened"
- Updates help text to: "Stick to the facts (what, where, when). Avoid opinions for now."
- No new questions, no logic changes, no infra changes