### PR TITLE
feat: add NotebookLM output adapter seam

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "stripe": "^20.3.0",
-        "tesseract.js": "^7.0.0"
+        "tesseract.js": "^7.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
@@ -37,7 +38,8 @@
         "eslint-config-next": "^14.2.35",
         "prisma": "^7.3.0",
         "tailwindcss": "^3.4.19",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -153,6 +155,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1089,6 +1533,356 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1146,6 +1940,31 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1899,6 +2718,117 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2145,6 +3075,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -2566,6 +3506,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3168,6 +4118,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "dev": true,
@@ -3218,6 +4175,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -3656,6 +4655,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
@@ -3671,6 +4680,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -5117,6 +6136,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "dev": true,
@@ -5590,6 +6619,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/ohash": {
       "version": "2.0.11",
@@ -6600,6 +7640,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6861,6 +7946,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6947,6 +8039,13 @@
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7418,6 +8517,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -7469,6 +8575,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7769,6 +8885,204 @@
         }
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/wasm-feature-detect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
@@ -7886,6 +9200,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -8041,6 +9372,15 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "prisma:linux:generate": "docker run --rm -v \"%cd%:/app\" -w /app node:20-bullseye bash -lc \"export DATABASE_URL=\\\"${DATABASE_URL:-$(grep DATABASE_URL .env | cut -d= -f2-)}\\\" && npm install && npx prisma generate\"",
     "prisma:linux:migrate": "docker run --rm -v \"%cd%:/app\" -w /app node:20-bullseye bash -lc \"export DATABASE_URL=\\\"${DATABASE_URL:-$(grep DATABASE_URL .env | cut -d= -f2-)}\\\" && npm install && npx prisma migrate dev\"",
     "prisma:linux:push": "docker run --rm -v \"%cd%:/app\" -w /app node:20-bullseye bash -lc \"export DATABASE_URL=\\\"${DATABASE_URL:-$(grep DATABASE_URL .env | cut -d= -f2-)}\\\" && npm install && npx prisma db push\"",
-    "prisma:linux:smoke": "docker run --rm -v \"%cd%:/app\" -w /app node:20-bullseye bash -lc \"export DATABASE_URL=\\\"${DATABASE_URL:-$(grep DATABASE_URL .env | cut -d= -f2-)}\\\" && npm install && npx tsx scripts/db-smoke-test.ts\""
+    "prisma:linux:smoke": "docker run --rm -v \"%cd%:/app\" -w /app node:20-bullseye bash -lc \"export DATABASE_URL=\\\"${DATABASE_URL:-$(grep DATABASE_URL .env | cut -d= -f2-)}\\\" && npm install && npx tsx scripts/db-smoke-test.ts\"",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "autoprefixer": "^10.4.23",
@@ -35,7 +37,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "stripe": "^20.3.0",
-    "tesseract.js": "^7.0.0"
+    "tesseract.js": "^7.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
@@ -52,6 +55,7 @@
     "eslint-config-next": "^14.2.35",
     "prisma": "^7.3.0",
     "tailwindcss": "^3.4.19",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/lib/__tests__/harness.test.ts
+++ b/src/lib/__tests__/harness.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("Test harness", () => {
+    it("runs a trivial assertion", () => {
+        expect(1 + 1).toBe(2);
+    });
+});

--- a/src/lib/brain/notebookLMAdapter.server.test.ts
+++ b/src/lib/brain/notebookLMAdapter.server.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { getSafeNotebookLMOutput } from "./notebookLMAdapter.server";
+
+// ─── Fixture ────────────────────────────────────────────────────────
+
+function validOutputJson(): string {
+    return JSON.stringify({
+        section_1_summary: "Summary of the case position.",
+        section_2_position: "Your position is strong based on NTK timing.",
+        section_3_reasoning: "The operator failed to issue within 14 days.",
+        section_4_evidence_requests: "Gather the original NTK letter.",
+        section_5_next_steps: "Submit your appeal to POPLA within 28 days.",
+        section_6_risks_and_limits:
+            "The operator may escalate. This is not legal advice.",
+        metadata: {
+            contract_version: "v1",
+            generated_at_iso: "2026-02-10T00:00:00.000Z",
+        },
+    });
+}
+
+// ─── Integration Tests ──────────────────────────────────────────────
+
+describe("getSafeNotebookLMOutput", () => {
+    it("passes valid model output through unchanged", () => {
+        const result = getSafeNotebookLMOutput(validOutputJson());
+        expect(result.safe_mode_used).toBe(false);
+        expect(result.reason).toBeUndefined();
+        expect(result.output.section_1_summary).toBe(
+            "Summary of the case position."
+        );
+        expect(result.output.metadata.contract_version).toBe("v1");
+    });
+
+    it("returns fallback for invalid JSON", () => {
+        const result = getSafeNotebookLMOutput("this is not valid json");
+        expect(result.safe_mode_used).toBe(true);
+        expect(result.reason).toBeDefined();
+        expect(result.output.metadata.safe_mode_used).toBe(true);
+        expect(result.output.metadata.contract_version).toBe("v1");
+        // All 6 sections must be present in fallback
+        expect(result.output.section_1_summary).toBeTruthy();
+        expect(result.output.section_6_risks_and_limits).toBeTruthy();
+    });
+
+    it("returns fallback with reason 'forbidden_language' for unsafe content", () => {
+        const unsafeOutput = JSON.stringify({
+            section_1_summary: "We guarantee you will win this case.",
+            section_2_position: "Your position is strong.",
+            section_3_reasoning: "The operator failed to comply.",
+            section_4_evidence_requests: "Gather the original NTK letter.",
+            section_5_next_steps: "Submit your appeal.",
+            section_6_risks_and_limits: "This is not legal advice.",
+            metadata: {
+                contract_version: "v1",
+                generated_at_iso: "2026-02-10T00:00:00.000Z",
+            },
+        });
+
+        const result = getSafeNotebookLMOutput(unsafeOutput);
+        expect(result.safe_mode_used).toBe(true);
+        expect(result.reason).toBe("forbidden_language");
+        expect(result.output.metadata.safe_mode_used).toBe(true);
+    });
+});

--- a/src/lib/brain/notebookLMAdapter.server.ts
+++ b/src/lib/brain/notebookLMAdapter.server.ts
@@ -1,0 +1,46 @@
+/**
+ * NotebookLM Output Adapter (Server-Side)
+ *
+ * Designated ingestion seam for all NotebookLM model output.
+ * Routes raw model text through contract enforcement, ensuring
+ * fail-closed safety before any output reaches downstream consumers.
+ *
+ * This is the ONLY function that should receive raw NotebookLM output.
+ */
+
+import {
+    enforceNotebookLMContract,
+    type EnforcementResult,
+    type NotebookLMFallbackMode,
+} from "@/lib/notebooklm-contract";
+import { auditLog } from "@/lib/ops/auditLog.server";
+
+export type SafeNotebookLMOutputOptions = {
+    fallbackMode?: NotebookLMFallbackMode;
+    caseId?: string;
+};
+
+/**
+ * Process raw NotebookLM model output through contract enforcement.
+ *
+ * - Valid output: passes through unchanged.
+ * - Invalid/unsafe output: returns deterministic safe fallback.
+ * - NEVER throws. Always returns a usable result.
+ */
+export function getSafeNotebookLMOutput(
+    rawText: string,
+    opts?: SafeNotebookLMOutputOptions
+): EnforcementResult {
+    const result = enforceNotebookLMContract(rawText, opts?.fallbackMode);
+
+    auditLog({
+        eventType: result.safe_mode_used
+            ? "NOTEBOOKLM_OUTPUT_FALLBACK"
+            : "NOTEBOOKLM_OUTPUT_ACCEPTED",
+        caseId: opts?.caseId,
+        reason: result.reason,
+        status: result.safe_mode_used ? "fallback" : "ok",
+    });
+
+    return result;
+}

--- a/src/lib/notebooklm-contract/contract.test.ts
+++ b/src/lib/notebooklm-contract/contract.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import {
+    NotebookLMInputSchema,
+    NotebookLMOutputSchema,
+    SECTION_MAX_CHARS,
+    containsForbiddenLanguage,
+} from "./index";
+
+// ─── Fixtures ───────────────────────────────────────────────────────
+
+function validInput() {
+    return {
+        case_id: "case-abc-123",
+        notice_type: "PRIVATE_PARKING" as const,
+        user_intent: "CHALLENGE" as const,
+        strategy: {
+            selected_path: "private_parking_challenge",
+            selected_strategy: "KEEPER_LIABILITY_CHALLENGE",
+            strength_signal: "STRONG" as const,
+            proceed_advice: "PROCEED" as const,
+            checklist: ["Gather NTK evidence", "Check timing"],
+            fallbacks: ["Request payment plan"],
+            determinism: {
+                version: "1.0.0",
+                rule_ids: ["rule_ntk_timing", "rule_keeper_liability"],
+            },
+        },
+        facts: {
+            pcnNumber: "ABC123",
+            issuer: "ParkingEye",
+            eventDate: "2026-01-15",
+        },
+        evidence: {
+            uploads: {
+                has_notice: true,
+                has_photos: false,
+                has_correspondence: false,
+                other: false,
+            },
+            evidence_flags: ["notice_uploaded"],
+            extracted_text_available: false,
+        },
+        constraints: {
+            approved_sources: ["BPA_CODE_2024", "POFA_2012"],
+            forbidden_language_profile: "motoring_v1" as const,
+            tone_profile: "calm_authoritative" as const,
+            jurisdiction: "UK" as const,
+        },
+    };
+}
+
+function validOutput() {
+    return {
+        section_1_summary: "Summary of the case position.",
+        section_2_position: "Your position is strong based on NTK timing.",
+        section_3_reasoning: "The operator failed to issue within 14 days.",
+        section_4_evidence_requests: "Gather the original NTK letter.",
+        section_5_next_steps: "Submit your appeal to POPLA within 28 days.",
+        section_6_risks_and_limits:
+            "The operator may escalate. This is not legal advice.",
+        metadata: {
+            contract_version: "v1" as const,
+            generated_at_iso: "2026-02-10T00:00:00.000Z",
+        },
+    };
+}
+
+// ─── Input Schema Tests ─────────────────────────────────────────────
+
+describe("NotebookLMInputSchema", () => {
+    it("accepts a valid input", () => {
+        const result = NotebookLMInputSchema.safeParse(validInput());
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects input with missing case_id", () => {
+        const input = validInput();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (input as any).case_id;
+        const result = NotebookLMInputSchema.safeParse(input);
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects input with invalid notice_type", () => {
+        const input = { ...validInput(), notice_type: "TRAFFIC_FINE" };
+        const result = NotebookLMInputSchema.safeParse(input);
+        expect(result.success).toBe(false);
+    });
+});
+
+// ─── Output Schema Tests ────────────────────────────────────────────
+
+describe("NotebookLMOutputSchema", () => {
+    it("accepts a valid output", () => {
+        const result = NotebookLMOutputSchema.safeParse(validOutput());
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects output missing a section (section_5_next_steps)", () => {
+        const output = validOutput();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (output as any).section_5_next_steps;
+        const result = NotebookLMOutputSchema.safeParse(output);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            const paths = result.error.issues.map((i) => i.path.join("."));
+            expect(paths).toContain("section_5_next_steps");
+        }
+    });
+
+    it("rejects output with an extra unexpected key (strict mode)", () => {
+        const output = {
+            ...validOutput(),
+            section_7_extra: "This should not exist",
+        };
+        const result = NotebookLMOutputSchema.safeParse(output);
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects output where a section exceeds max length", () => {
+        const output = {
+            ...validOutput(),
+            section_1_summary: "x".repeat(SECTION_MAX_CHARS + 1),
+        };
+        const result = NotebookLMOutputSchema.safeParse(output);
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects output with empty section", () => {
+        const output = { ...validOutput(), section_3_reasoning: "" };
+        const result = NotebookLMOutputSchema.safeParse(output);
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects output with wrong contract_version", () => {
+        const output = {
+            ...validOutput(),
+            metadata: { ...validOutput().metadata, contract_version: "v2" },
+        };
+        const result = NotebookLMOutputSchema.safeParse(output);
+        expect(result.success).toBe(false);
+    });
+});
+
+// ─── Forbidden Language Tests ───────────────────────────────────────
+
+describe("containsForbiddenLanguage", () => {
+    it("detects a forbidden phrase", () => {
+        const result = containsForbiddenLanguage(
+            "We guaranteed you will win this case."
+        );
+        expect(result.hit).toBe(true);
+        expect(result.matches.length).toBeGreaterThan(0);
+    });
+
+    it("detects forbidden pattern (threat language)", () => {
+        const result = containsForbiddenLanguage(
+            "This is your final warning before legal action."
+        );
+        expect(result.hit).toBe(true);
+    });
+
+    it("returns hit=false for clean text", () => {
+        const result = containsForbiddenLanguage(
+            "Based on the available evidence, your case has merit. We recommend proceeding with a calm, factual appeal."
+        );
+        expect(result.hit).toBe(false);
+    });
+
+    it("is case-insensitive for phrases", () => {
+        const result = containsForbiddenLanguage("GUARANTEED outcome for you.");
+        expect(result.hit).toBe(true);
+    });
+});

--- a/src/lib/notebooklm-contract/contract.ts
+++ b/src/lib/notebooklm-contract/contract.ts
@@ -1,0 +1,100 @@
+/**
+ * NotebookLM Contract v1 — Zod Schemas
+ *
+ * Strict schemas defining the exact shape of data flowing between
+ * the Strategy Engine and NotebookLM.
+ *
+ * - NotebookLMInputSchema:  what the engine sends TO NotebookLM
+ * - NotebookLMOutputSchema: what NotebookLM MUST return (strict — no extra keys)
+ *
+ * RULE: Strategy Engine DECIDES. NotebookLM DRAFTS + EXPLAINS only.
+ * NotebookLM must never decide routing, eligibility, or outcomes.
+ */
+
+import { z } from "zod";
+
+// ─── Configurable Limits ────────────────────────────────────────────
+
+/** Maximum character length for any single output section. */
+export const SECTION_MAX_CHARS = 2000;
+
+/** Minimum character length for any single output section. */
+export const SECTION_MIN_CHARS = 1;
+
+// ─── Input Schema ───────────────────────────────────────────────────
+
+const StrategyBlockSchema = z.object({
+    selected_path: z.string(),
+    selected_strategy: z.string(),
+    strength_signal: z.enum(["STRONG", "MIXED", "WEAK"]),
+    proceed_advice: z.enum(["PROCEED", "PROCEED_WITH_CAUTION", "DO_NOT_PROCEED"]),
+    checklist: z.array(z.string()),
+    fallbacks: z.array(z.string()),
+    determinism: z.object({
+        version: z.string(),
+        rule_ids: z.array(z.string()),
+    }),
+});
+
+const EvidenceBlockSchema = z.object({
+    uploads: z.object({
+        has_notice: z.boolean(),
+        has_photos: z.boolean(),
+        has_correspondence: z.boolean(),
+        other: z.boolean(),
+    }),
+    evidence_flags: z.array(z.string()),
+    extracted_text_available: z.boolean(),
+});
+
+const ConstraintsBlockSchema = z.object({
+    approved_sources: z.array(z.string()),
+    forbidden_language_profile: z.literal("motoring_v1"),
+    tone_profile: z.literal("calm_authoritative"),
+    jurisdiction: z.literal("UK"),
+});
+
+export const NotebookLMInputSchema = z.object({
+    case_id: z.string().min(1),
+    notice_type: z.enum(["COUNCIL_PCN", "PRIVATE_PARKING", "CAMERA_MATTER"]),
+    user_intent: z.enum(["CHALLENGE", "AFFORDABILITY"]),
+    strategy: StrategyBlockSchema,
+    facts: z.record(z.string(), z.unknown()),
+    evidence: EvidenceBlockSchema,
+    constraints: ConstraintsBlockSchema,
+});
+
+/** TypeScript type inferred from the input schema. */
+export type NotebookLMInput = z.infer<typeof NotebookLMInputSchema>;
+
+// ─── Output Schema ──────────────────────────────────────────────────
+
+const SectionSchema = z
+    .string()
+    .min(SECTION_MIN_CHARS, "Section must not be empty")
+    .max(SECTION_MAX_CHARS, `Section must not exceed ${SECTION_MAX_CHARS} characters`);
+
+const OutputMetadataSchema = z.object({
+    contract_version: z.literal("v1"),
+    generated_at_iso: z.string().min(1),
+    safe_mode_used: z.boolean().optional(),
+});
+
+/**
+ * The output schema is STRICT: no extra keys allowed at top level.
+ * NotebookLM must return EXACTLY these 6 sections + metadata.
+ */
+export const NotebookLMOutputSchema = z
+    .object({
+        section_1_summary: SectionSchema,
+        section_2_position: SectionSchema,
+        section_3_reasoning: SectionSchema,
+        section_4_evidence_requests: SectionSchema,
+        section_5_next_steps: SectionSchema,
+        section_6_risks_and_limits: SectionSchema,
+        metadata: OutputMetadataSchema,
+    })
+    .strict();
+
+/** TypeScript type inferred from the output schema. */
+export type NotebookLMOutput = z.infer<typeof NotebookLMOutputSchema>;

--- a/src/lib/notebooklm-contract/enforce.test.ts
+++ b/src/lib/notebooklm-contract/enforce.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from "vitest";
+import {
+    parseNotebookLMJson,
+    validateNotebookLMOutput,
+    buildFallbackOutput,
+    enforceNotebookLMContract,
+} from "./enforce";
+import { SECTION_MAX_CHARS } from "./contract";
+import { containsForbiddenLanguage } from "./forbiddenLanguage";
+
+// ─── Fixtures ───────────────────────────────────────────────────────
+
+function validOutput() {
+    return {
+        section_1_summary: "Summary of the case position.",
+        section_2_position: "Your position is strong based on NTK timing.",
+        section_3_reasoning: "The operator failed to issue within 14 days.",
+        section_4_evidence_requests: "Gather the original NTK letter.",
+        section_5_next_steps: "Submit your appeal to POPLA within 28 days.",
+        section_6_risks_and_limits:
+            "The operator may escalate. This is not legal advice.",
+        metadata: {
+            contract_version: "v1" as const,
+            generated_at_iso: "2026-02-10T00:00:00.000Z",
+        },
+    };
+}
+
+function validOutputJson(): string {
+    return JSON.stringify(validOutput());
+}
+
+// ─── parseNotebookLMJson ────────────────────────────────────────────
+
+describe("parseNotebookLMJson", () => {
+    it("parses valid JSON", () => {
+        const result = parseNotebookLMJson('{"a":1}');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value).toEqual({ a: 1 });
+        }
+    });
+
+    it("returns error for invalid JSON", () => {
+        const result = parseNotebookLMJson("not json at all {{{");
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toBeTruthy();
+        }
+    });
+
+    it("returns error for empty string", () => {
+        const result = parseNotebookLMJson("");
+        expect(result.ok).toBe(false);
+    });
+});
+
+// ─── validateNotebookLMOutput ───────────────────────────────────────
+
+describe("validateNotebookLMOutput", () => {
+    it("accepts a valid output object", () => {
+        const result = validateNotebookLMOutput(validOutput());
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.output.section_1_summary).toBe(
+                "Summary of the case position."
+            );
+        }
+    });
+
+    it("rejects output missing a section (schema_invalid)", () => {
+        const output = validOutput();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (output as any).section_5_next_steps;
+        const result = validateNotebookLMOutput(output);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe("schema_invalid");
+        }
+    });
+
+    it("rejects output with extra unexpected key (schema_invalid via strict)", () => {
+        const output = {
+            ...validOutput(),
+            section_7_bonus: "Should not exist",
+        };
+        const result = validateNotebookLMOutput(output);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe("schema_invalid");
+        }
+    });
+
+    it("rejects output with over-length section", () => {
+        const output = {
+            ...validOutput(),
+            section_1_summary: "x".repeat(SECTION_MAX_CHARS + 1),
+        };
+        const result = validateNotebookLMOutput(output);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            // Zod catches this too since max is in schema, but reason should indicate the issue
+            expect(["over_length", "schema_invalid"]).toContain(result.reason);
+        }
+    });
+
+    it("rejects output with forbidden language in a section", () => {
+        const output = {
+            ...validOutput(),
+            section_2_position: "We guarantee you will win this case.",
+        };
+        const result = validateNotebookLMOutput(output);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe("forbidden_language");
+        }
+    });
+
+    it("rejects output with forbidden language in section_6", () => {
+        const output = {
+            ...validOutput(),
+            section_6_risks_and_limits:
+                "This is your final warning before we proceed.",
+        };
+        const result = validateNotebookLMOutput(output);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe("forbidden_language");
+        }
+    });
+
+    it("rejects null input", () => {
+        const result = validateNotebookLMOutput(null);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe("schema_invalid");
+        }
+    });
+});
+
+// ─── buildFallbackOutput ────────────────────────────────────────────
+
+describe("buildFallbackOutput", () => {
+    it("produces exactly 6 sections + metadata (SAFE_EXPLANATION_ONLY)", () => {
+        const output = buildFallbackOutput(
+            "SAFE_EXPLANATION_ONLY",
+            "schema_invalid"
+        );
+        expect(output.section_1_summary).toBeTruthy();
+        expect(output.section_2_position).toBeTruthy();
+        expect(output.section_3_reasoning).toBeTruthy();
+        expect(output.section_4_evidence_requests).toBeTruthy();
+        expect(output.section_5_next_steps).toBeTruthy();
+        expect(output.section_6_risks_and_limits).toBeTruthy();
+        expect(output.metadata.contract_version).toBe("v1");
+        expect(output.metadata.safe_mode_used).toBe(true);
+        expect(output.metadata.generated_at_iso).toBeTruthy();
+    });
+
+    it("produces exactly 6 sections + metadata (DO_NOT_PROCEED_NOTICE)", () => {
+        const output = buildFallbackOutput(
+            "DO_NOT_PROCEED_NOTICE",
+            "forbidden_language"
+        );
+        expect(output.section_1_summary).toBeTruthy();
+        expect(output.section_2_position).toBeTruthy();
+        expect(output.section_3_reasoning).toBeTruthy();
+        expect(output.section_4_evidence_requests).toBeTruthy();
+        expect(output.section_5_next_steps).toBeTruthy();
+        expect(output.section_6_risks_and_limits).toBeTruthy();
+        expect(output.metadata.contract_version).toBe("v1");
+        expect(output.metadata.safe_mode_used).toBe(true);
+    });
+
+    it("includes the failure reason in section_3_reasoning", () => {
+        const output = buildFallbackOutput(
+            "SAFE_EXPLANATION_ONLY",
+            "over_length"
+        );
+        expect(output.section_3_reasoning).toContain("over_length");
+    });
+
+    it("never contains forbidden language itself", () => {
+        for (const mode of [
+            "SAFE_EXPLANATION_ONLY",
+            "DO_NOT_PROCEED_NOTICE",
+        ] as const) {
+            const output = buildFallbackOutput(mode, "schema_invalid");
+            const allText = [
+                output.section_1_summary,
+                output.section_2_position,
+                output.section_3_reasoning,
+                output.section_4_evidence_requests,
+                output.section_5_next_steps,
+                output.section_6_risks_and_limits,
+            ].join(" ");
+            const check = containsForbiddenLanguage(allText);
+            expect(check.hit).toBe(false);
+        }
+    });
+
+    it("fallback output itself passes schema validation", () => {
+        const output = buildFallbackOutput(
+            "SAFE_EXPLANATION_ONLY",
+            "schema_invalid"
+        );
+        const result = validateNotebookLMOutput(output);
+        expect(result.ok).toBe(true);
+    });
+});
+
+// ─── enforceNotebookLMContract ──────────────────────────────────────
+
+describe("enforceNotebookLMContract", () => {
+    it("returns valid output with safe_mode_used=false for valid JSON", () => {
+        const result = enforceNotebookLMContract(validOutputJson());
+        expect(result.safe_mode_used).toBe(false);
+        expect(result.reason).toBeUndefined();
+        expect(result.output.section_1_summary).toBe(
+            "Summary of the case position."
+        );
+    });
+
+    it("returns fallback for invalid JSON", () => {
+        const result = enforceNotebookLMContract("this is not json");
+        expect(result.safe_mode_used).toBe(true);
+        expect(result.reason).toBe("schema_invalid");
+        expect(result.output.metadata.safe_mode_used).toBe(true);
+        expect(result.output.metadata.contract_version).toBe("v1");
+    });
+
+    it("returns fallback for missing section", () => {
+        const output = validOutput();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (output as any).section_3_reasoning;
+        const result = enforceNotebookLMContract(JSON.stringify(output));
+        expect(result.safe_mode_used).toBe(true);
+        expect(result.reason).toBe("schema_invalid");
+    });
+
+    it("returns fallback for forbidden language", () => {
+        const output = {
+            ...validOutput(),
+            section_1_summary: "We guarantee you will definitely win.",
+        };
+        const result = enforceNotebookLMContract(JSON.stringify(output));
+        expect(result.safe_mode_used).toBe(true);
+        expect(result.reason).toBe("forbidden_language");
+    });
+
+    it("returns fallback for over-length section", () => {
+        const output = {
+            ...validOutput(),
+            section_2_position: "x".repeat(SECTION_MAX_CHARS + 1),
+        };
+        const result = enforceNotebookLMContract(JSON.stringify(output));
+        expect(result.safe_mode_used).toBe(true);
+        // Zod catches length in schema, so reason is schema_invalid
+        expect(["over_length", "schema_invalid"]).toContain(result.reason);
+    });
+
+    it("respects fallbackMode override to DO_NOT_PROCEED_NOTICE", () => {
+        const result = enforceNotebookLMContract(
+            "bad json",
+            "DO_NOT_PROCEED_NOTICE"
+        );
+        expect(result.safe_mode_used).toBe(true);
+        // DO_NOT_PROCEED content mentions "professional review"
+        expect(result.output.section_2_position).toContain(
+            "professional review"
+        );
+    });
+
+    it("defaults fallbackMode to SAFE_EXPLANATION_ONLY", () => {
+        const result = enforceNotebookLMContract("bad json");
+        expect(result.safe_mode_used).toBe(true);
+        // SAFE_EXPLANATION content mentions "safe explanation"
+        expect(result.output.section_1_summary).toContain("safe explanation");
+    });
+});

--- a/src/lib/notebooklm-contract/enforce.ts
+++ b/src/lib/notebooklm-contract/enforce.ts
@@ -1,0 +1,267 @@
+/**
+ * NotebookLM Contract v1 — Runtime Enforcement (Phase N2)
+ *
+ * Fail-closed enforcement layer. Validates NotebookLM model output
+ * against the v1 contract schema, scans for forbidden language,
+ * and returns either validated output OR a deterministic safe fallback.
+ *
+ * RULE: If ANYTHING is invalid or unsafe → fallback. Never allow
+ * unsafe output through.
+ */
+
+import {
+    NotebookLMOutputSchema,
+    SECTION_MAX_CHARS,
+    type NotebookLMOutput,
+} from "./contract";
+import { containsForbiddenLanguage } from "./forbiddenLanguage";
+import type {
+    NotebookLMValidationFailureReason,
+    NotebookLMFallbackMode,
+} from "./types";
+
+// ─── Section Keys ───────────────────────────────────────────────────
+
+const SECTION_KEYS = [
+    "section_1_summary",
+    "section_2_position",
+    "section_3_reasoning",
+    "section_4_evidence_requests",
+    "section_5_next_steps",
+    "section_6_risks_and_limits",
+] as const;
+
+const EXPECTED_SECTION_COUNT = 6;
+
+// ─── 1. Safe JSON Parser ────────────────────────────────────────────
+
+/**
+ * Parse a raw JSON string safely. Never uses eval.
+ * Returns a discriminated union so callers can handle failure without try/catch.
+ */
+export function parseNotebookLMJson(
+    raw: string
+): { ok: true; value: unknown } | { ok: false; error: string } {
+    try {
+        const value: unknown = JSON.parse(raw);
+        return { ok: true, value };
+    } catch (err) {
+        const message =
+            err instanceof Error ? err.message : "Unknown JSON parse error";
+        return { ok: false, error: message };
+    }
+}
+
+// ─── 2. Output Validator ────────────────────────────────────────────
+
+export type ValidationSuccess = { ok: true; output: NotebookLMOutput };
+export type ValidationFailure = {
+    ok: false;
+    reason: NotebookLMValidationFailureReason;
+    details?: string;
+};
+export type ValidationResult = ValidationSuccess | ValidationFailure;
+
+/**
+ * Multi-step strict validation of a parsed NotebookLM output object.
+ *
+ * Order:
+ *   a) Zod strict schema parse
+ *   b) Defensive section count check (exactly 6)
+ *   c) Per-section length ≤ SECTION_MAX_CHARS
+ *   d) Forbidden language scan on all sections + metadata.generated_at_iso
+ */
+export function validateNotebookLMOutput(raw: unknown): ValidationResult {
+    // ── Step A: Zod strict schema validation ──
+    const zodResult = NotebookLMOutputSchema.safeParse(raw);
+    if (!zodResult.success) {
+        const paths = zodResult.error.issues.map(
+            (i) => `${i.path.join(".")}: ${i.message}`
+        );
+        return {
+            ok: false,
+            reason: "schema_invalid",
+            details: `Zod validation failed: ${paths.join("; ")}`,
+        };
+    }
+
+    const output = zodResult.data;
+
+    // ── Step B: Defensive section count check ──
+    const presentSections = SECTION_KEYS.filter(
+        (k) => k in output && typeof output[k] === "string"
+    );
+    if (presentSections.length < EXPECTED_SECTION_COUNT) {
+        return {
+            ok: false,
+            reason: "missing_sections",
+            details: `Expected ${EXPECTED_SECTION_COUNT} sections, found ${presentSections.length}`,
+        };
+    }
+
+    // Check for unexpected keys beyond the 6 sections + metadata
+    const allowedKeys = new Set<string>([...SECTION_KEYS, "metadata"]);
+    const extraKeys = Object.keys(output).filter((k) => !allowedKeys.has(k));
+    if (extraKeys.length > 0) {
+        return {
+            ok: false,
+            reason: "extra_sections",
+            details: `Unexpected keys: ${extraKeys.join(", ")}`,
+        };
+    }
+
+    // ── Step C: Section length checks ──
+    for (const key of SECTION_KEYS) {
+        const section = output[key];
+        if (section.length > SECTION_MAX_CHARS) {
+            return {
+                ok: false,
+                reason: "over_length",
+                details: `${key} has ${section.length} chars (max ${SECTION_MAX_CHARS})`,
+            };
+        }
+    }
+
+    // ── Step D: Forbidden language scan ──
+    // Scan all section content AND the generated_at_iso metadata field
+    // (it's the only string metadata that could carry injected content)
+    const textsToScan: string[] = SECTION_KEYS.map((k) => output[k]);
+    textsToScan.push(output.metadata.generated_at_iso);
+
+    for (let i = 0; i < textsToScan.length; i++) {
+        const result = containsForbiddenLanguage(textsToScan[i]);
+        if (result.hit) {
+            const field =
+                i < SECTION_KEYS.length
+                    ? SECTION_KEYS[i]
+                    : "metadata.generated_at_iso";
+            return {
+                ok: false,
+                reason: "forbidden_language",
+                details: `Forbidden language in ${field}: ${result.matches.join("; ")}`,
+            };
+        }
+    }
+
+    // ── All checks passed ──
+    return { ok: true, output };
+}
+
+// ─── 3. Fallback Builder ────────────────────────────────────────────
+
+/**
+ * Build a deterministic safe fallback output.
+ * No external calls. Produces EXACTLY 6 sections with ethical disclosure.
+ */
+export function buildFallbackOutput(
+    mode: NotebookLMFallbackMode,
+    reason: NotebookLMValidationFailureReason
+): NotebookLMOutput {
+    if (mode === "DO_NOT_PROCEED_NOTICE") {
+        return {
+            section_1_summary:
+                "The automated analysis could not produce a validated output for this case. " +
+                "This does not reflect on the merits of your situation.",
+            section_2_position:
+                "We are unable to provide a position assessment at this time. " +
+                "The system has determined that proceeding without professional review would not be appropriate.",
+            section_3_reasoning:
+                "The analysis output did not meet the required safety and quality standards. " +
+                `Validation failure reason: ${reason}. ` +
+                "This is a precautionary measure to ensure you receive accurate information.",
+            section_4_evidence_requests:
+                "Please retain all documents related to your case, including the original notice, " +
+                "any correspondence, photographs, and receipts. These may be needed for professional review.",
+            section_5_next_steps:
+                "We recommend seeking independent legal advice or contacting a relevant advisory service " +
+                "such as Citizens Advice (England & Wales) before taking any further action on this matter.",
+            section_6_risks_and_limits:
+                "This output was generated in safe mode due to a validation failure. " +
+                "It does not constitute legal advice and makes no promises about outcomes. " +
+                "Parking and motoring matters can have financial and legal consequences. " +
+                "Always verify information independently and consider seeking professional legal advice.",
+            metadata: {
+                contract_version: "v1",
+                generated_at_iso: new Date().toISOString(),
+                safe_mode_used: true,
+            },
+        };
+    }
+
+    // Default: SAFE_EXPLANATION_ONLY
+    return {
+        section_1_summary:
+            "The automated analysis was unable to produce a fully validated result. " +
+            "A safe explanation has been generated instead.",
+        section_2_position:
+            "Based on the information available, a detailed position could not be determined. " +
+            "This may be due to incomplete data or a processing issue, not a reflection of your case merits.",
+        section_3_reasoning:
+            "The system applies strict validation to all generated content to ensure accuracy and safety. " +
+            `The output did not pass validation (reason: ${reason}). ` +
+            "This safe fallback has been provided to ensure you are not given unverified information.",
+        section_4_evidence_requests:
+            "To help with your case, please gather and retain all relevant documents: " +
+            "the original notice, any letters or emails exchanged, photographs of signage or location, " +
+            "and proof of any payments made.",
+        section_5_next_steps:
+            "You may wish to review your case details and try again, or seek guidance from " +
+            "an advisory service such as Citizens Advice. No action is required immediately " +
+            "unless a deadline is approaching on your notice.",
+        section_6_risks_and_limits:
+            "This output was generated in safe mode due to a validation failure. " +
+            "It does not constitute legal advice and makes no promises about outcomes. " +
+            "All information should be independently verified. " +
+            "Consider seeking professional legal advice for your specific circumstances.",
+        metadata: {
+            contract_version: "v1",
+            generated_at_iso: new Date().toISOString(),
+            safe_mode_used: true,
+        },
+    };
+}
+
+// ─── 4. Top-Level Enforcement Orchestrator ──────────────────────────
+
+export type EnforcementResult = {
+    output: NotebookLMOutput;
+    safe_mode_used: boolean;
+    reason?: NotebookLMValidationFailureReason;
+};
+
+/**
+ * Top-level enforcement: parse JSON → validate → return valid output or fallback.
+ *
+ * This function NEVER throws. It always returns a usable NotebookLMOutput.
+ * If anything fails, it returns a deterministic safe fallback.
+ */
+export function enforceNotebookLMContract(
+    rawModelOutputText: string,
+    fallbackMode: NotebookLMFallbackMode = "SAFE_EXPLANATION_ONLY"
+): EnforcementResult {
+    // Step 1: Parse JSON
+    const parsed = parseNotebookLMJson(rawModelOutputText);
+    if (!parsed.ok) {
+        return {
+            output: buildFallbackOutput(fallbackMode, "schema_invalid"),
+            safe_mode_used: true,
+            reason: "schema_invalid",
+        };
+    }
+
+    // Step 2: Validate
+    const validated = validateNotebookLMOutput(parsed.value);
+    if (!validated.ok) {
+        return {
+            output: buildFallbackOutput(fallbackMode, validated.reason),
+            safe_mode_used: true,
+            reason: validated.reason,
+        };
+    }
+
+    // Step 3: All checks passed — return validated output
+    return {
+        output: validated.output,
+        safe_mode_used: false,
+    };
+}

--- a/src/lib/notebooklm-contract/forbiddenLanguage.ts
+++ b/src/lib/notebooklm-contract/forbiddenLanguage.ts
@@ -1,0 +1,110 @@
+/**
+ * NotebookLM Contract v1 — Forbidden Language
+ *
+ * Centralized list of phrases and patterns that must NEVER appear in
+ * NotebookLM-generated output. Phase N2 will wire runtime scanning;
+ * this file defines the constants and a detection helper.
+ *
+ * Philosophy: conservative — block anything that could be read as a
+ * guarantee, threat, or outcome promise. Ethics over persuasion.
+ */
+
+// ─── Forbidden Phrases ──────────────────────────────────────────────
+// Exact substrings (case-insensitive matching). Keep alphabetically sorted.
+
+export const FORBIDDEN_PHRASES: readonly string[] = [
+    "assured outcome",
+    "certain to succeed",
+    "certainly win",
+    "final chance",
+    "final warning",
+    "guaranteed",
+    "guaranteed outcome",
+    "guaranteed result",
+    "guaranteed success",
+    "ignore this and",
+    "last warning",
+    "must cancel",
+    "must pay",
+    "this is illegal",
+    "we guarantee",
+    "we promise",
+    "will definitely",
+    "will win",
+    "you are entitled to cancel",
+    "you will succeed",
+    "you will win",
+] as const;
+
+// ─── Forbidden Patterns ─────────────────────────────────────────────
+// Regex pattern strings for more nuanced matching.
+
+export const FORBIDDEN_PATTERN_STRINGS: readonly string[] = [
+    // Promise / guarantee language
+    "\\b(guarantee[ds]?|assured|certain to)\\b",
+    // Threat language
+    "\\b(final\\s+(chance|warning|notice)|last\\s+warning|legal\\s+action\\s+will)\\b",
+    // Outcome certainty
+    "\\b(you\\s+will\\s+(definitely|certainly|surely)\\s+(win|succeed))\\b",
+    // Illegality assertions (stating something IS illegal, vs explaining the law)
+    "\\b(this\\s+is\\s+illegal|they\\s+have\\s+broken\\s+the\\s+law)\\b",
+    // Coercive payment language
+    "\\b(must\\s+(pay|cancel)|have\\s+no\\s+choice)\\b",
+] as const;
+
+// ─── Compiled Regexes ───────────────────────────────────────────────
+
+let _compiledPatterns: RegExp[] | null = null;
+
+/** Returns compiled RegExp[] from FORBIDDEN_PATTERN_STRINGS (cached). */
+export function getForbiddenPhraseRegexes(): RegExp[] {
+    if (!_compiledPatterns) {
+        _compiledPatterns = FORBIDDEN_PATTERN_STRINGS.map(
+            (p) => new RegExp(p, "gi")
+        );
+    }
+    // Reset lastIndex on each call to avoid stale state from global flag
+    for (const r of _compiledPatterns) r.lastIndex = 0;
+    return _compiledPatterns;
+}
+
+// ─── Detection Helper ───────────────────────────────────────────────
+
+export type ForbiddenLanguageResult = {
+    hit: boolean;
+    matches: string[];
+};
+
+/**
+ * Scans `text` for any forbidden language.
+ * Returns `{ hit: true, matches: [...] }` if any match is found.
+ */
+export function containsForbiddenLanguage(
+    text: string
+): ForbiddenLanguageResult {
+    const lower = text.toLowerCase();
+    const matches: string[] = [];
+
+    // 1. Check exact phrases
+    for (const phrase of FORBIDDEN_PHRASES) {
+        if (lower.includes(phrase.toLowerCase())) {
+            matches.push(`phrase: "${phrase}"`);
+        }
+    }
+
+    // 2. Check regex patterns
+    const regexes = getForbiddenPhraseRegexes();
+    for (let i = 0; i < regexes.length; i++) {
+        const re = regexes[i];
+        re.lastIndex = 0;
+        const match = re.exec(text);
+        if (match) {
+            matches.push(`pattern: "${FORBIDDEN_PATTERN_STRINGS[i]}" matched "${match[0]}"`);
+        }
+    }
+
+    return {
+        hit: matches.length > 0,
+        matches,
+    };
+}

--- a/src/lib/notebooklm-contract/index.ts
+++ b/src/lib/notebooklm-contract/index.ts
@@ -1,0 +1,55 @@
+/**
+ * NotebookLM Contract v1 — Barrel Exports
+ */
+
+// Types & enums
+export type {
+    NoticeType,
+    UserIntent,
+    StrengthSignal,
+    ProceedAdvice,
+    DeterminismBlock,
+    ToneProfile,
+    ForbiddenLanguageProfile,
+    NotebookLMContractVersion,
+    NotebookLMValidationFailureReason,
+    NotebookLMFallbackMode,
+    NotebookLMValidationResult,
+} from "./types";
+
+export { CURRENT_CONTRACT_VERSION } from "./types";
+
+// Forbidden language
+export {
+    FORBIDDEN_PHRASES,
+    FORBIDDEN_PATTERN_STRINGS,
+    getForbiddenPhraseRegexes,
+    containsForbiddenLanguage,
+} from "./forbiddenLanguage";
+
+export type { ForbiddenLanguageResult } from "./forbiddenLanguage";
+
+// Schemas & inferred types
+export {
+    NotebookLMInputSchema,
+    NotebookLMOutputSchema,
+    SECTION_MAX_CHARS,
+    SECTION_MIN_CHARS,
+} from "./contract";
+
+export type { NotebookLMInput, NotebookLMOutput } from "./contract";
+
+// Enforcement (Phase N2)
+export {
+    parseNotebookLMJson,
+    validateNotebookLMOutput,
+    buildFallbackOutput,
+    enforceNotebookLMContract,
+} from "./enforce";
+
+export type {
+    ValidationResult,
+    ValidationSuccess,
+    ValidationFailure,
+    EnforcementResult,
+} from "./enforce";

--- a/src/lib/notebooklm-contract/types.ts
+++ b/src/lib/notebooklm-contract/types.ts
@@ -1,0 +1,72 @@
+/**
+ * NotebookLM Contract v1 — Shared Types & Enums
+ *
+ * These types define the vocabulary shared between the Strategy Engine
+ * (deterministic) and the NotebookLM drafting layer.
+ *
+ * RULE: Strategy Engine DECIDES. NotebookLM DRAFTS + EXPLAINS only.
+ */
+
+// ─── Notice & Intent ────────────────────────────────────────────────
+
+export type NoticeType = "COUNCIL_PCN" | "PRIVATE_PARKING" | "CAMERA_MATTER";
+
+export type UserIntent = "CHALLENGE" | "AFFORDABILITY";
+
+// ─── Strategy Signals (set by Strategy Engine, read-only for NotebookLM) ──
+
+export type StrengthSignal = "STRONG" | "MIXED" | "WEAK";
+
+export type ProceedAdvice =
+    | "PROCEED"
+    | "PROCEED_WITH_CAUTION"
+    | "DO_NOT_PROCEED";
+
+// ─── Determinism Block ──────────────────────────────────────────────
+
+/** Attached to every input so the output can be traced to exact engine rules. */
+export type DeterminismBlock = {
+    /** Engine version that produced the strategy decision. */
+    version: string;
+    /** IDs of the rules that fired to produce this strategy. */
+    rule_ids: string[];
+};
+
+// ─── Tone & Language Profiles ───────────────────────────────────────
+
+export type ToneProfile = "calm_authoritative";
+
+export type ForbiddenLanguageProfile = "motoring_v1";
+
+// ─── Contract Version ───────────────────────────────────────────────
+
+export type NotebookLMContractVersion = "v1";
+
+export const CURRENT_CONTRACT_VERSION: NotebookLMContractVersion = "v1";
+
+// ─── Validation & Fallback ──────────────────────────────────────────
+
+export type NotebookLMValidationFailureReason =
+    | "schema_invalid"
+    | "missing_sections"
+    | "extra_sections"
+    | "forbidden_language"
+    | "over_length"
+    | "unapproved_source_reference"
+    | "unsafe_tone"
+    | "other";
+
+export type NotebookLMFallbackMode =
+    | "SAFE_EXPLANATION_ONLY"
+    | "DO_NOT_PROCEED_NOTICE";
+
+/** Result of validating a NotebookLM output against the contract. */
+export type NotebookLMValidationResult = {
+    valid: boolean;
+    failures: Array<{
+        reason: NotebookLMValidationFailureReason;
+        detail: string;
+    }>;
+    /** If invalid, which fallback mode should the UI render? */
+    fallback_mode: NotebookLMFallbackMode | null;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+    test: {
+        include: ["src/**/*.test.ts"],
+        environment: "node",
+    },
+    resolve: {
+        alias: {
+            "@": path.resolve(__dirname, "src"),
+        },
+    },
+});


### PR DESCRIPTION
Phase N3: Creates the designated server-side ingestion seam for NotebookLM output (getSafeNotebookLMOutput) that routes text through enforceNotebookLMContract. Adds adapter-level vitest coverage. No UI/infra/DB changes.