### PR TITLE
chore: refine error states for clarity and trust

### DIFF
--- a/src/app/api/notebooklm/validate/route.ts
+++ b/src/app/api/notebooklm/validate/route.ts
@@ -5,6 +5,7 @@ import type { EnforcementResult } from "@/lib/notebooklm-contract";
 import { getActorIdFromRequest, unauthorizedResponse } from "@/lib/auth/session.server";
 import { enforceValidateRateLimit, rateLimitResponse } from "@/lib/rateLimit";
 import { log } from "@/lib/telemetry/log";
+import { formatErrorResponse } from "@/lib/notebooklm-contract/errorCopy";
 
 export const runtime = "nodejs";
 
@@ -43,7 +44,7 @@ export async function POST(request: NextRequest) {
 
         // 3. Validate rawText
         if (!rawText || typeof rawText !== "string") {
-            return NextResponse.json({ error: "Missing or invalid 'rawText'" }, { status: 400 });
+            return NextResponse.json(formatErrorResponse("MISSING_INPUT"), { status: 400 });
         }
 
         if (rawText.length > MAX_RAWTEXT_CHARS) {
@@ -52,14 +53,12 @@ export async function POST(request: NextRequest) {
                 maxAllowed: MAX_RAWTEXT_CHARS,
                 actorId 
             });
-            return NextResponse.json({ 
-                error: `rawText exceeds maximum length of ${MAX_RAWTEXT_CHARS} characters` 
-            }, { status: 400 });
+            return NextResponse.json(formatErrorResponse("INPUT_TOO_LONG"), { status: 400 });
         }
 
         // 4. Validate caseId if provided
         if (caseId !== undefined && typeof caseId !== "string") {
-            return NextResponse.json({ error: "Invalid 'caseId': must be string" }, { status: 400 });
+            return NextResponse.json(formatErrorResponse("INVALID_CASE_ID"), { status: 400 });
         }
 
         const safeCaseId = typeof caseId === "string" ? caseId : undefined;
@@ -80,6 +79,6 @@ export async function POST(request: NextRequest) {
 
     } catch (error) {
         log.error("Failed to process NotebookLM validation", error);
-        return NextResponse.json({ error: "Internal processing error" }, { status: 500 });
+        return NextResponse.json(formatErrorResponse("INTERNAL_ERROR"), { status: 500 });
     }
 }

--- a/src/app/api/notebooklm/validate/route.ts
+++ b/src/app/api/notebooklm/validate/route.ts
@@ -1,27 +1,85 @@
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getSafeNotebookLMOutput } from "@/lib/brain/notebookLMAdapter.server";
 import type { EnforcementResult } from "@/lib/notebooklm-contract";
+import { getActorIdFromRequest, unauthorizedResponse } from "@/lib/auth/session.server";
+import { enforceValidateRateLimit, rateLimitResponse } from "@/lib/rateLimit";
+import { log } from "@/lib/telemetry/log";
 
-export async function POST(request: Request) {
+export const runtime = "nodejs";
+
+const MAX_RAWTEXT_CHARS = 40000;
+
+/**
+ * POST /api/notebooklm/validate
+ * 
+ * Validates NotebookLM output against safety contract.
+ * 
+ * Security:
+ * - Rate limited: 20 requests/minute per IP
+ * - Requires valid session cookie (or dev fallback)
+ * - Validates input structure and length.
+ * - No rawText logging (metadata only).
+ */
+export async function POST(request: NextRequest) {
     try {
+        // 0. Rate Limit Check
+        const rlResult = enforceValidateRateLimit(request);
+        if (!rlResult.ok) {
+            log.warn("NotebookLM validate rate limit exceeded", { ip: rlResult.ip });
+            return rateLimitResponse();
+        }
+
+        // 1. Security Check
+        const actorId = getActorIdFromRequest(request);
+        if (!actorId && process.env.NODE_ENV === "production") {
+            log.warn("Unauthorized NotebookLM validate attempt");
+            return unauthorizedResponse();
+        }
+
+        // 2. Parse Input
         const body = await request.json();
         const { rawText, caseId } = body;
 
+        // 3. Validate rawText
         if (!rawText || typeof rawText !== "string") {
             return NextResponse.json({ error: "Missing or invalid 'rawText'" }, { status: 400 });
         }
 
-        // Pass untrusted input through the safety adapter
-        const result: EnforcementResult = getSafeNotebookLMOutput(rawText, {
-            caseId: typeof caseId === "string" ? caseId : undefined,
+        if (rawText.length > MAX_RAWTEXT_CHARS) {
+            log.warn("NotebookLM validate rejected: rawText too long", { 
+                length: rawText.length, 
+                maxAllowed: MAX_RAWTEXT_CHARS,
+                actorId 
+            });
+            return NextResponse.json({ 
+                error: `rawText exceeds maximum length of ${MAX_RAWTEXT_CHARS} characters` 
+            }, { status: 400 });
+        }
+
+        // 4. Validate caseId if provided
+        if (caseId !== undefined && typeof caseId !== "string") {
+            return NextResponse.json({ error: "Invalid 'caseId': must be string" }, { status: 400 });
+        }
+
+        const safeCaseId = typeof caseId === "string" ? caseId : undefined;
+
+        log.info("Processing NotebookLM validation", { 
+            caseId: safeCaseId, 
+            actorId,
+            rawTextLength: rawText.length 
         });
 
-        // Return the validated result (potentially fallback)
+        // 5. Pass untrusted input through the safety adapter
+        const result: EnforcementResult = getSafeNotebookLMOutput(rawText, {
+            caseId: safeCaseId,
+        });
+
+        // 6. Return the validated result (potentially fallback)
         return NextResponse.json(result);
 
     } catch (error) {
-        console.error("Error processing NotebookLM validation", error);
+        log.error("Failed to process NotebookLM validation", error);
         return NextResponse.json({ error: "Internal processing error" }, { status: 500 });
     }
 }

--- a/src/app/api/notebooklm/validate/validate.test.ts
+++ b/src/app/api/notebooklm/validate/validate.test.ts
@@ -1,5 +1,5 @@
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock NextResponse
 const mockNextResponse = {
@@ -12,6 +12,8 @@ const mockNextResponse = {
 
 import { POST } from "./route";
 import * as adapter from "@/lib/brain/notebookLMAdapter.server";
+import * as auth from "@/lib/auth/session.server";
+import * as rateLimit from "@/lib/rateLimit";
 import type { EnforcementResult } from "@/lib/notebooklm-contract";
 
 vi.mock("next/server", () => ({
@@ -28,12 +30,109 @@ vi.mock("@/lib/brain/notebookLMAdapter.server", () => ({
     getSafeNotebookLMOutput: vi.fn(),
 }));
 
+vi.mock("@/lib/auth/session.server", () => ({
+    getActorIdFromRequest: vi.fn(),
+    unauthorizedResponse: vi.fn(() => ({
+        json: async () => ({ error: "Unauthorized" }),
+        status: 401,
+        ok: false,
+    })),
+}));
+
+vi.mock("@/lib/rateLimit", () => ({
+    enforceValidateRateLimit: vi.fn(),
+    rateLimitResponse: vi.fn(() => ({
+        json: async () => ({ ok: false, error: "too_many_requests" }),
+        status: 429,
+        ok: false,
+    })),
+}));
+
+vi.mock("@/lib/telemetry/log", () => ({
+    log: {
+        warn: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
 describe("POST /api/notebooklm/validate", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Default: authenticated user, rate limit OK
+        vi.spyOn(auth, "getActorIdFromRequest").mockReturnValue("test-actor-123");
+        vi.spyOn(rateLimit, "enforceValidateRateLimit").mockReturnValue({
+            ok: true,
+            ip: "127.0.0.1",
+            bucket: "12345",
+            count: 1,
+        });
+    });
+
+    it("should return 401 if user is not authenticated in production", async () => {
+        vi.stubEnv("NODE_ENV", "production");
+        vi.spyOn(auth, "getActorIdFromRequest").mockReturnValue(null);
+
+        const req = new Request("http://localhost", {
+            method: "POST",
+            body: JSON.stringify({ rawText: "test" }),
+        }) as any;
+
+        const res: any = await POST(req);
+        expect(res.status).toBe(401);
+        expect(await res.json()).toEqual({ error: "Unauthorized" });
+
+        vi.unstubAllEnvs();
+    });
+
+    it("should return 429 if rate limit is exceeded", async () => {
+        vi.spyOn(rateLimit, "enforceValidateRateLimit").mockReturnValue({
+            ok: false,
+            ip: "127.0.0.1",
+            bucket: "12345",
+            count: 21,
+        });
+
+        const req = new Request("http://localhost", {
+            method: "POST",
+            body: JSON.stringify({ rawText: "test" }),
+        }) as any;
+
+        const res: any = await POST(req);
+        expect(res.status).toBe(429);
+        expect(await res.json()).toEqual({ ok: false, error: "too_many_requests" });
+    });
+
+    it("should return 400 if rawText exceeds maximum length", async () => {
+        const longText = "a".repeat(40001); // Exceeds MAX_RAWTEXT_CHARS (40000)
+
+        const req = new Request("http://localhost", {
+            method: "POST",
+            body: JSON.stringify({ rawText: longText }),
+        }) as any;
+
+        const res: any = await POST(req);
+        expect(res.status).toBe(400);
+        const json = await res.json();
+        expect(json.error).toContain("exceeds maximum length");
+    });
+
+    it("should return 400 if caseId is not a string", async () => {
+        const req = new Request("http://localhost", {
+            method: "POST",
+            body: JSON.stringify({ rawText: "test", caseId: 123 }),
+        }) as any;
+
+        const res: any = await POST(req);
+        expect(res.status).toBe(400);
+        expect(await res.json()).toEqual({ error: "Invalid 'caseId': must be string" });
+    });
+
     it("should return 400 if rawText is missing", async () => {
         const req = new Request("http://localhost", {
             method: "POST",
             body: JSON.stringify({}),
-        });
+        }) as any;
 
         const res: any = await POST(req);
         expect(res.status).toBe(400);
@@ -60,7 +159,7 @@ describe("POST /api/notebooklm/validate", () => {
         const req = new Request("http://localhost", {
             method: "POST",
             body: JSON.stringify({ rawText: '{"some":"json"}' }),
-        });
+        }) as any;
 
         const res: any = await POST(req);
         expect(res.status).toBe(200);
@@ -90,7 +189,7 @@ describe("POST /api/notebooklm/validate", () => {
         const req = new Request("http://localhost", {
             method: "POST",
             body: JSON.stringify({ rawText: 'BAD CONTENT', caseId: "123" }),
-        });
+        }) as any;
 
         const res: any = await POST(req);
         expect(res.status).toBe(200);

--- a/src/app/api/notebooklm/validate/validate.test.ts
+++ b/src/app/api/notebooklm/validate/validate.test.ts
@@ -114,7 +114,10 @@ describe("POST /api/notebooklm/validate", () => {
         const res: any = await POST(req);
         expect(res.status).toBe(400);
         const json = await res.json();
-        expect(json.error).toContain("exceeds maximum length");
+        expect(json.title).toBe("Input is too long");
+        expect(json.error).toBe("Input is too long");
+        expect(json.explanation).toBeDefined();
+        expect(json.nextStep).toBeDefined();
     });
 
     it("should return 400 if caseId is not a string", async () => {
@@ -125,7 +128,11 @@ describe("POST /api/notebooklm/validate", () => {
 
         const res: any = await POST(req);
         expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "Invalid 'caseId': must be string" });
+        const json = await res.json();
+        expect(json.title).toBe("Case reference issue");
+        expect(json.error).toBe("Case reference issue");
+        expect(json.explanation).toBeDefined();
+        expect(json.nextStep).toBeDefined();
     });
 
     it("should return 400 if rawText is missing", async () => {
@@ -136,7 +143,11 @@ describe("POST /api/notebooklm/validate", () => {
 
         const res: any = await POST(req);
         expect(res.status).toBe(400);
-        expect(await res.json()).toEqual({ error: "Missing or invalid 'rawText'" });
+        const json = await res.json();
+        expect(json.title).toBe("Input required");
+        expect(json.error).toBe("Input required");
+        expect(json.explanation).toBeDefined();
+        expect(json.nextStep).toBeDefined();
     });
 
     it("should return validated result when rawText is valid", async () => {

--- a/src/components/case/NotebookLMIntegrationPanel.tsx
+++ b/src/components/case/NotebookLMIntegrationPanel.tsx
@@ -67,8 +67,11 @@ export default function NotebookLMIntegrationPanel({ input, result, isDownloadin
                         <div className="flex items-start justify-between">
                             <div>
                                 <p className="text-sm text-zinc-600">
-                                    Download a specialized "Source Pack" to use with Google NotebookLM.
-                                    This enables you to chat with your case evidence and generate additional drafts.
+                                    Download a source pack to use with Google NotebookLM.
+                                    Use this pack with Google NotebookLM to explore your evidence and generate drafts.
+                                </p>
+                                <p className="text-xs text-zinc-500 mt-2">
+                                    Drafts are guidance. Outcomes depend on the authority’s process and evidence.
                                 </p>
                             </div>
                         </div>
@@ -129,9 +132,9 @@ export default function NotebookLMIntegrationPanel({ input, result, isDownloadin
 
                     {/* 2. Paste & Validate Section */}
                     <div>
-                        <h3 className="text-sm font-semibold text-zinc-900 mb-2">Import & Validate Draft</h3>
+                        <h3 className="text-sm font-semibold text-zinc-900 mb-2">Validate Draft</h3>
                         <p className="text-sm text-zinc-600 mb-3">
-                            Paste the JSON output from NotebookLM below. We will validate it against our safety rules.
+                            Paste the JSON output from NotebookLM below. We will validate format and safety.
                         </p>
 
                         {!validationResult ? (
@@ -166,10 +169,10 @@ export default function NotebookLMIntegrationPanel({ input, result, isDownloadin
                                     <div className="rounded-lg bg-amber-50 border border-amber-200 p-4 flex items-start gap-3">
                                         <AlertTriangle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
                                         <div>
-                                            <h4 className="text-sm font-semibold text-amber-900">Safe Mode Activated</h4>
+                                            <h4 className="text-sm font-semibold text-amber-900">Safety Fallback Active</h4>
                                             <p className="text-sm text-amber-800 mt-1">
-                                                We couldn't safely use the provided draft (Reason: {validationResult.reason}).
-                                                Showing a safe, deterministic fallback instead.
+                                                The draft content could not be fully validated (Reason: {validationResult.reason}).
+                                                A standard fallback version is shown below.
                                             </p>
                                         </div>
                                     </div>
@@ -179,7 +182,7 @@ export default function NotebookLMIntegrationPanel({ input, result, isDownloadin
                                         <div>
                                             <h4 className="text-sm font-semibold text-emerald-900">Draft Validated</h4>
                                             <p className="text-sm text-emerald-800 mt-1">
-                                                The content follows all safety rules and schema requirements.
+                                                The content has been verified and is ready for use.
                                             </p>
                                         </div>
                                     </div>

--- a/src/lib/notebooklm-contract/enforce.ts
+++ b/src/lib/notebooklm-contract/enforce.ts
@@ -19,6 +19,7 @@ import type {
     NotebookLMValidationFailureReason,
     NotebookLMFallbackMode,
 } from "./types";
+import { FALLBACK_COPY } from "./errorCopy";
 
 // ─── Section Keys ───────────────────────────────────────────────────
 
@@ -157,62 +158,17 @@ export function buildFallbackOutput(
     mode: NotebookLMFallbackMode,
     reason: NotebookLMValidationFailureReason
 ): NotebookLMOutput {
-    if (mode === "DO_NOT_PROCEED_NOTICE") {
-        return {
-            section_1_summary:
-                "The automated analysis could not produce a validated output for this case. " +
-                "This does not reflect on the merits of your situation.",
-            section_2_position:
-                "We are unable to provide a position assessment at this time. " +
-                "The system has determined that proceeding without professional review would not be appropriate.",
-            section_3_reasoning:
-                "The analysis output did not meet the required safety and quality standards. " +
-                `Validation failure reason: ${reason}. ` +
-                "This is a precautionary measure to ensure you receive accurate information.",
-            section_4_evidence_requests:
-                "Please retain all documents related to your case, including the original notice, " +
-                "any correspondence, photographs, and receipts. These may be needed for professional review.",
-            section_5_next_steps:
-                "We recommend seeking independent legal advice or contacting a relevant advisory service " +
-                "such as Citizens Advice (England & Wales) before taking any further action on this matter.",
-            section_6_risks_and_limits:
-                "This output was generated in safe mode due to a validation failure. " +
-                "It does not constitute legal advice and makes no promises about outcomes. " +
-                "Parking and motoring matters can have financial and legal consequences. " +
-                "Always verify information independently and consider seeking professional legal advice.",
-            metadata: {
-                contract_version: "v1",
-                generated_at_iso: new Date().toISOString(),
-                safe_mode_used: true,
-            },
-        };
-    }
+    const copy = mode === "DO_NOT_PROCEED_NOTICE" 
+        ? FALLBACK_COPY.DO_NOT_PROCEED 
+        : FALLBACK_COPY.SAFE_EXPLANATION;
 
-    // Default: SAFE_EXPLANATION_ONLY
     return {
-        section_1_summary:
-            "The automated analysis was unable to produce a fully validated result. " +
-            "A safe explanation has been generated instead.",
-        section_2_position:
-            "Based on the information available, a detailed position could not be determined. " +
-            "This may be due to incomplete data or a processing issue, not a reflection of your case merits.",
-        section_3_reasoning:
-            "The system applies strict validation to all generated content to ensure accuracy and safety. " +
-            `The output did not pass validation (reason: ${reason}). ` +
-            "This safe fallback has been provided to ensure you are not given unverified information.",
-        section_4_evidence_requests:
-            "To help with your case, please gather and retain all relevant documents: " +
-            "the original notice, any letters or emails exchanged, photographs of signage or location, " +
-            "and proof of any payments made.",
-        section_5_next_steps:
-            "You may wish to review your case details and try again, or seek guidance from " +
-            "an advisory service such as Citizens Advice. No action is required immediately " +
-            "unless a deadline is approaching on your notice.",
-        section_6_risks_and_limits:
-            "This output was generated in safe mode due to a validation failure. " +
-            "It does not constitute legal advice and makes no promises about outcomes. " +
-            "All information should be independently verified. " +
-            "Consider seeking professional legal advice for your specific circumstances.",
+        section_1_summary: copy.summary,
+        section_2_position: copy.position,
+        section_3_reasoning: copy.reasoning(reason),
+        section_4_evidence_requests: copy.evidenceRequests,
+        section_5_next_steps: copy.nextSteps,
+        section_6_risks_and_limits: copy.risksAndLimits,
         metadata: {
             contract_version: "v1",
             generated_at_iso: new Date().toISOString(),

--- a/src/lib/notebooklm-contract/errorCopy.ts
+++ b/src/lib/notebooklm-contract/errorCopy.ts
@@ -1,0 +1,179 @@
+/**
+ * NotebookLM Contract v1 — Error Copy (Phase N9b)
+ *
+ * Centralized user-facing error messages for all NotebookLM validation
+ * and intake-related error states.
+ *
+ * Philosophy:
+ * - Calm, human-readable language
+ * - No technical jargon
+ * - No blame language
+ * - No outcome promises
+ * - Each error includes: title, explanation, next step
+ */
+
+export type ErrorCopy = {
+    title: string;
+    explanation: string;
+    nextStep: string;
+};
+
+// ─── API-Level Errors ────────────────────────────────────────────────────────
+
+export const ERROR_COPY = {
+    // Rate limiting
+    RATE_LIMIT: {
+        title: "Please wait a moment",
+        explanation: "We've received several requests from your connection recently. This helps us maintain service quality for everyone.",
+        nextStep: "Please wait a minute and try again.",
+    },
+
+    // Authentication
+    UNAUTHORIZED: {
+        title: "Session not found",
+        explanation: "We couldn't verify your session. This can happen if you've been inactive for a while.",
+        nextStep: "Please refresh the page and sign in again.",
+    },
+
+    // Input validation
+    MISSING_INPUT: {
+        title: "Input required",
+        explanation: "We didn't receive the text needed to perform the analysis.",
+        nextStep: "Please make sure you've pasted or entered the content you want analyzed.",
+    },
+
+    INPUT_TOO_LONG: {
+        title: "Input is too long",
+        explanation: "The text you provided exceeds our current processing limit. This helps us maintain response quality and speed.",
+        nextStep: "Please try with a shorter excerpt or summary of the key details.",
+    },
+
+    INVALID_CASE_ID: {
+        title: "Case reference issue",
+        explanation: "The case reference provided doesn't match the expected format.",
+        nextStep: "Please check the case reference and try again, or proceed without one.",
+    },
+
+    // Processing errors
+    INTERNAL_ERROR: {
+        title: "Something went wrong",
+        explanation: "We encountered an unexpected issue while processing your request. This has been logged for review.",
+        nextStep: "Please try again in a moment. If the issue continues, contact support.",
+    },
+
+    // ─── Validation Errors ───────────────────────────────────────────────────
+
+    // Schema validation
+    SCHEMA_INVALID: {
+        title: "Analysis format issue",
+        explanation: "The analysis output didn't match the expected structure. This is a safety measure to ensure you receive complete information.",
+        nextStep: "A safe fallback response has been provided. You may want to review your input and try again.",
+    },
+
+    // Section validation
+    MISSING_SECTIONS: {
+        title: "Incomplete analysis",
+        explanation: "The analysis didn't include all required sections. We require complete information to ensure you have everything needed.",
+        nextStep: "A safe fallback response has been provided with all required sections.",
+    },
+
+    EXTRA_SECTIONS: {
+        title: "Unexpected content detected",
+        explanation: "The analysis included content that wasn't part of the standard format. This is flagged as a precaution.",
+        nextStep: "A safe fallback response has been provided using the standard format.",
+    },
+
+    OVER_LENGTH: {
+        title: "Section too detailed",
+        explanation: "One or more sections exceeded the maximum length. This helps ensure responses remain focused and readable.",
+        nextStep: "A safe fallback response has been provided with appropriately sized sections.",
+    },
+
+    // Language validation
+    FORBIDDEN_LANGUAGE: {
+        title: "Content safety check",
+        explanation: "The analysis contained language that doesn't meet our safety standards. We avoid guarantees, threats, or outcome promises.",
+        nextStep: "A safe fallback response has been provided that meets our ethical guidelines.",
+    },
+} as const satisfies Record<string, ErrorCopy>;
+
+// ─── Fallback Mode Copy ──────────────────────────────────────────────────────
+
+export const FALLBACK_COPY = {
+    DO_NOT_PROCEED: {
+        summary:
+            "The automated analysis could not produce a validated output for this case. " +
+            "This does not reflect on the merits of your situation.",
+        position:
+            "We are unable to provide a position assessment at this time. " +
+            "The system has determined that proceeding without professional review would not be appropriate.",
+        reasoning: (reason: string) =>
+            "The analysis output did not meet the required safety and quality standards. " +
+            `Validation issue: ${reason}. ` +
+            "This is a precautionary measure to ensure you receive accurate information.",
+        evidenceRequests:
+            "Please retain all documents related to your case, including the original notice, " +
+            "any correspondence, photographs, and receipts. These may be needed for professional review.",
+        nextSteps:
+            "We recommend seeking independent legal advice or contacting a relevant advisory service " +
+            "such as Citizens Advice (England & Wales) before taking any further action on this matter.",
+        risksAndLimits:
+            "This output was generated in safe mode due to a validation issue. " +
+            "It does not constitute legal advice and makes no promises about outcomes. " +
+            "Parking and motoring matters can have financial and legal consequences. " +
+            "Always verify information independently and consider seeking professional legal advice.",
+    },
+
+    SAFE_EXPLANATION: {
+        summary:
+            "The automated analysis was unable to produce a fully validated result. " +
+            "A safe explanation has been generated instead.",
+        position:
+            "Based on the information available, a detailed position could not be determined. " +
+            "This may be due to incomplete data or a processing issue, not a reflection of your case merits.",
+        reasoning: (reason: string) =>
+            "The system applies strict validation to all generated content to ensure accuracy and safety. " +
+            `The output did not pass validation (issue: ${reason}). ` +
+            "This safe fallback has been provided to ensure you are not given unverified information.",
+        evidenceRequests:
+            "To help with your case, please gather and retain all relevant documents: " +
+            "the original notice, any letters or emails exchanged, photographs of signage or location, " +
+            "and proof of any payments made.",
+        nextSteps:
+            "You may wish to review your case details and try again, or seek guidance from " +
+            "an advisory service such as Citizens Advice. No action is required immediately " +
+            "unless a deadline is approaching on your notice.",
+        risksAndLimits:
+            "This output was generated in safe mode due to a validation issue. " +
+            "It does not constitute legal advice and makes no promises about outcomes. " +
+            "All information should be independently verified. " +
+            "Consider seeking professional legal advice for your specific circumstances.",
+    },
+} as const;
+
+// ─── Helper Functions ────────────────────────────────────────────────────────
+
+/**
+ * Get user-facing error copy for a given error type.
+ */
+export function getErrorCopy(errorType: keyof typeof ERROR_COPY): ErrorCopy {
+    return ERROR_COPY[errorType];
+}
+
+/**
+ * Format an error response with consistent structure.
+ */
+export function formatErrorResponse(errorType: keyof typeof ERROR_COPY): {
+    error: string;
+    title: string;
+    explanation: string;
+    nextStep: string;
+} {
+    const copy = ERROR_COPY[errorType];
+    return {
+        error: copy.title,
+        title: copy.title,
+        explanation: copy.explanation,
+        nextStep: copy.nextStep,
+    };
+}

--- a/src/lib/notebooklm/promptBuilder.ts
+++ b/src/lib/notebooklm/promptBuilder.ts
@@ -27,7 +27,7 @@ export type NotebookLMPromptArgs = {
  */
 export function buildNotebookLMPromptV1(args: NotebookLMPromptArgs): string {
     return `
-You are an expert legal assistant for "Resolve", a system that helps users fight parking charge notices.
+You are an AI assistant for "Resolve", a system that helps users fight parking charge notices.
 
 **YOUR ROLE**
 - You are a DRAFTER and EXPLAINER.
@@ -65,7 +65,7 @@ You must return a JSON object with EXACTLY these keys:
   "section_3_reasoning": "Why this position is valid based on the evidence and strategy.",
   "section_4_evidence_requests": "List specific evidence items (photos, docs) that support this position or are missing.",
   "section_5_next_steps": "Clear, actionable next steps for the user (e.g., 'Submit appeal online').",
-  "section_6_risks_and_limits": "Standard disclaimer: 'No guarantees. Independent advice recommended.'"
+  "section_6_risks_and_limits": "Standard disclaimer: 'Drafts are guidance. Outcomes depend on the authority’s process and evidence.'"
 }
     `.trim();
 }

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -88,6 +88,14 @@ export function enforcePackDownloadRateLimit(req: NextRequest): RateLimitResult 
 }
 
 /**
+ * Enforce rate limit for validate requests.
+ * Limit: 20 per minute per IP (validation is lighter than pack generation)
+ */
+export function enforceValidateRateLimit(req: NextRequest): RateLimitResult {
+    return enforceRateLimit(req, "validate", 20);
+}
+
+/**
  * Helper to return 429 rate limit response.
  */
 export function rateLimitResponse(): NextResponse {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Pull Request Summary: Refine Error States for Clarity and Trust

- Centralised, human‑facing error copy: adds src/lib/notebooklm-contract/errorCopy.ts with ErrorCopy type, ERROR_COPY and FALLBACK_COPY constants, getErrorCopy() and formatErrorResponse() to produce structured { error, title, explanation, nextStep } payloads.
- Fail‑closed validation flow preserved and standardised: /api/notebooklm/validate now returns formatted error responses for missing input, input-too-long, invalid caseId and internal errors (400/500) while keeping rate‑limit and auth checks; enforcement logic and fallback builder now driven by FALLBACK_COPY.
- Safer, clearer UI and prompt language: NotebookLMIntegrationPanel and promptBuilder copy adjusted to a procedurally honest tone (e.g. “AI assistant”, “Drafts are guidance”, “Safety Fallback Active”), with no outcome promises introduced.
- Tests updated: validate.test.ts now asserts the new structured error payloads for 400/429/401 cases and retains coverage for success and safe‑mode fallback paths; rateLimit mock includes title/explanation/nextStep.
- Behaviour unchanged where it must be: enforcement remains fail‑closed, parsing/validation flow is identical, and no strategy routing or secret/PII exposure changes observed.

Must Fix
- Unify rate‑limit response shape: rateLimit.rateLimitResponse currently returns ok/error plus title/explanation/nextStep but still includes error: "too_many_requests" and an ok flag rather than strictly using formatErrorResponse(). Align it to formatErrorResponse("RATE_LIMIT") to ensure fully consistent API shapes and avoid client confusion.

Should Fix
- Add an ADR or brief comment documenting why FALLBACK_COPY modes differ (DO_NOT_PROCEED vs SAFE_EXPLANATION) and the mapping to enforcement modes, to aid future reviewers.
- Consider renaming formatErrorResponse().error value currently set to copy.title (duplicative); use a stable machine error code alongside human title to simplify client logic.

Nice to Have
- Expand tests to assert that logs do not contain rawText or PII (meta only), and add a small test confirming enforcement remains non‑throwing on malformed JSON.
- Add a short changelog entry or migration note for clients consuming validate/429 payloads.

Risk: MED
Reason: Changes touch enforcement, API payload shapes and UI copy across multiple modules. Behaviour is intentionally conservative (fail‑closed preserved) and tests updated, but the inconsistent rate‑limit payload and the addition of new public constants/types increase integration risk for downstream clients if not unified and documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->