### PR TITLE
chore: set repo to maintenance mode (website-first focus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+# ❄️ RESOLVE ENGINE - MAINTENANCE MODE (FROZEN)
+
+> **STATUS: FROZEN FOR WEBSITE-FIRST FOCUS**
+> 
+> **Active Delivery:** Website-first DIY appeal builder (£1.99)
+> **Repo Status:** Reference Engine Only. No new app features.
+> **Allowed Changes:** Bugfixes, Security Patches, Test Fixes Only.
+
+This repository (`resolve-engine`) contains the core Strategy Engine, NotebookLM Contracts, and Enforcement Logic. It is currently frozen to allow the team to focus on the lightweight, website-first DIY service.
+
+## 🛑 Contribution Rules
+1. **No New Features**: Do not add UI features or expand the scope of this Next.js app.
+2. **Infrastructure/DB Locked**: No migrations or infra changes allowed.
+3. **PR Discipline**:
+   - All PRs must target `staging`.
+   - Squash & Merge only.
+   - Delete branch after merge.
+4. **Docs First**: If you are planning the website work, use the `docs/` folder here or the separate website repo.
+
+---
+
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Getting Started

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,39 @@
+# Governance: Maintenance Mode
+
+> **Effective Date:** 2026-02-10
+> **Status:** Active
+> **Authority:** Repo Steward
+
+## 1. Purpose
+The Resolve Engine application is being placed in **Maintenance Mode** to shift engineering focus to the **Website-First DIY Appeal Builder (£1.99)**. This decision prioritizes immediate user value (low-cost, self-service appeals) over the complex, fully managed web application.
+
+This repository now serves as the **Reference System** for:
+- Core Strategy Logic (Assessment Engine)
+- NotebookLM Prompts & Contracts
+- Legal/Compliance Text (Enforcement)
+
+## 2. Allowed Changes
+You may ONLY modify this repository for:
+- **Bug Fixes**: Critical logical errors in the engine or breaking UI bugs.
+- **Security Patches**: Vulnerability fixes in dependencies or code.
+- **Test Fixes**: Repairing broken E2E or unit tests to maintain green CI.
+- **Documentation**: Updating knowledge base, plans, or governance docs.
+
+## 3. Forbidden Changes
+- **New Features**: No new pages, workflows, or complex UI components.
+- **UX Expansion**: Do not polish or expand the intake/assessment flow.
+- **Infrastructure**: No changes to Vercel, Hetzner, Docker, or CI/CD pipelines.
+- **Database**: No schema migrations or new tables.
+- **Payments**: Do not activate Stripe webhooks or checkout flows in this app.
+
+## 4. Branch Discipline
+- **Feature Branches**: `fix/*`, `chore/*`, `docs/*`. Avoid `feat/*` unless authorized by Steward.
+- **Target Branch**: Always open PRs against `staging`.
+- **Merge Strategy**: Squash and Merge.
+- **Cleanup**: Delete source branch immediately after merge.
+
+## 5. Website-First Proposals
+If you are working on the Website V1:
+- Do not build it in this repo.
+- Creates issues or docs here labeled `website-v1` if they relate to extracting logic from the Engine.
+- Refer to `docs/website-first-plan.md` for architectural split.

--- a/docs/website-first-plan.md
+++ b/docs/website-first-plan.md
@@ -1,0 +1,34 @@
+# Website-First Plan: DIY Appeal Builder (£1.99)
+
+## 1. The Pivot
+We have decided to pause the full "Managed Service" web app to launch a streamlined **DIY Appeal Builder** website.
+- **Product:** A simple website where users answer questions and generate a PDF appeal pack.
+- **Price:** £1.99 one-off payment.
+- **Delivery:** Immediate download / email.
+- **No Account Required:** Guest checkout focus.
+
+## 2. Core Philosophy
+- **Ethics Over Pressure:** We do not guarantee outcomes. We sell "Procedural Literacy" and "Best-Effort Drafting".
+- **Calm Authority:** The tone is helpful, neutral, and expert. Never aggressive or "lawyer-y".
+- **Separation of Concerns:**
+  - **The Website** handles UI, user input, payment, and content delivery.
+  - **The Engine (This Repo)** defines the *logic* of the assessment and the *prompts* for generation.
+
+## 3. Architecture Split
+### What Stays Here (Resolve Engine Repo)
+This repo remains the Source of Truth for:
+- **Strategy Engine:** The rules that determine `appeal_possible` vs `pay_now`.
+- **NotebookLM Contract:** The structure of the JSON payload sent to AI.
+- **Prompts:** The actual system prompts and templates used to generate letters.
+- **Enforcement Rules:** Validation logic for PCN numbers, dates, etc.
+
+### What Moves to Website Repo
+- **Marketing Pages:** Landing page, pricing, FAQ.
+- **Simple Intake Form:** A lightweight version of the wizard (likely simplified).
+- **Stripe Integration:** Direct one-off payment links or lightweight checkout.
+- **PDF Generation:** The actual rendering of the PDF (using content defined by Engine).
+
+## 4. Maintenance Mode
+This repository is frozen to ensure the Engine logic remains stable while we iterate fast on the Website UI. We will port logic *from* here *to* the website, or expose this Engine as an API in Phase 2.
+
+**For now: Don't break the Engine. Build the Website separately.**


### PR DESCRIPTION
Freeze resolve-engine app as a reference engine while building website-first DIY appeal builder (£1.99).

- Tag created: app-freeze-2026-02-10
- Maintenance branch created: maintenance/app-freeze
- Docs added: governance + website-first plan
- No code, infra, or DB changes
